### PR TITLE
Piped StdErr to StdOut when using exec and added method to digest errors

### DIFF
--- a/src/Command.php
+++ b/src/Command.php
@@ -103,6 +103,7 @@ class Command
      * @param array $options array of name => value options that should be applied to the object
      * You can also pass options that use a setter, e.g. you can pass a 'fileName' option which
      * will be passed to setFileName().
+     * @throws \Exception
      * @return Command for method chaining
      */
     public function setOptions($options)


### PR DESCRIPTION
- Now, when using exec, STDERR will be piped to STDOUT, giving the library access to errors. This way, the output of `proc_open` and `exec` is exactly the same.
- To prevent differences in newlines between Windows and Nix, we use PHP_EOL
- Added a protected method to parse and digest wkHtmlToPdf errors (for both `exec` and `proc_open`)
