### PR TITLE
Don't trim stdout and stderr

### DIFF
--- a/src/Command.php
+++ b/src/Command.php
@@ -303,8 +303,8 @@ class Command
 
             if (is_resource($process)) {
 
-                $this->_stdOut = trim(stream_get_contents($pipes[1]));
-                $this->_stdErr = trim(stream_get_contents($pipes[2]));
+                $this->_stdOut = stream_get_contents($pipes[1]);
+                $this->_stdErr = stream_get_contents($pipes[2]);
                 fclose($pipes[1]);
                 fclose($pipes[2]);
 


### PR DESCRIPTION
I'm using this library to test the output of a shell script.  My script returns a newline at the end of the output.  The `trim()` calls remove this newline, thus causing my tests to fail:

![](https://dl.dropboxusercontent.com/u/449877/ShareX/2015/09/2015-09-19_09-03-35.png)

I think this library should keep the output as-is and let the user determine whether or not to trim the output.