### PR TITLE
Enable feeding a string from php to standard input

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ $command->addArg('--name=', "d'Artagnan");
 // Add argument with several values
 // results in --keys key1 key2
 $command->addArg('--keys', array('key1','key2'));
+
+// Add string to pipe to command on standard input
+$command->setStdIn('string');
 ```
 
 ## API
@@ -108,6 +111,7 @@ pass `command`, `execCommand` and `args` as options. This will call the respecti
        An array can be passed to add more than one value for a key, e.g. `addArg('--exclude', array('val1','val2'))`
        which will create the option "--exclude 'val1' 'val2'".
     * `$escape`: If set, this overrides the `$escapeArgs` setting and enforces escaping/no escaping
+ * `setStdIn()`: String to supply command via standard input.
  * `getOutput()`: The command output as string. Empty if none.
  * `getError()`: The error message, either stderr or internal message. Empty if no error.
  * `getStdErr()`: The stderr output. Empty if none.

--- a/src/Command.php
+++ b/src/Command.php
@@ -337,7 +337,7 @@ class Command
                 1   => array('pipe','w'),
                 2   => array('pipe', $this->getIsWindows() ? 'a' : 'w'),
             );
-            if (isset($this->_stdIn)) {
+            if ($this->_stdIn!==null) {
                 $descriptors[0] = array('pipe', 'r');
             }
 
@@ -345,7 +345,7 @@ class Command
 
             if (is_resource($process)) {
 
-                if(isset($this->_stdIn)) {
+                if($this->_stdIn!==null) {
                     fwrite($pipes[0], $this->_stdIn);
                     fclose($pipes[0]);
                 }

--- a/src/Command.php
+++ b/src/Command.php
@@ -60,6 +60,11 @@ class Command
     public $locale;
 
     /**
+     * @var string to pipe to standard input
+     */
+    protected $_stdIn;
+
+    /**
      * @var string the command to execute
      */
     protected $_command;
@@ -163,6 +168,16 @@ class Command
             }
         }
         $this->_command = $command;
+        return $this;
+    }
+
+    /**
+     * @param string $stdIn If set, the string will be piped to the command via standard input.
+     * This enables the same functionality as piping on the command line.
+     * @return static for method chaining
+     */
+    public function setStdIn($stdIn) {
+        $this->_stdIn = $stdIn;
         return $this;
     }
 
@@ -322,10 +337,18 @@ class Command
                 1   => array('pipe','w'),
                 2   => array('pipe', $this->getIsWindows() ? 'a' : 'w'),
             );
+            if (isset($this->_stdIn)) {
+                $descriptors[0] = array('pipe', 'r');
+            }
+
             $process = proc_open($command, $descriptors, $pipes, $this->procCwd, $this->procEnv, $this->procOptions);
 
             if (is_resource($process)) {
 
+                if(isset($this->_stdIn)) {
+                    fwrite($pipes[0], $this->_stdIn);
+                    fclose($pipes[0]);
+                }
                 $this->_stdOut = stream_get_contents($pipes[1]);
                 $this->_stdErr = stream_get_contents($pipes[2]);
                 fclose($pipes[1]);

--- a/tests/CommandTest.php
+++ b/tests/CommandTest.php
@@ -224,5 +224,14 @@ class CommandTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($command->getExecuted());
         $this->assertEquals($tmpDir, $command->getOutput());
     }
+    public function testCanRunCommandWithStandardInput()
+    {
+        $command = new Command('head');
+        $command->addArg('-n', 1);
+        $command->setStdIn("1\n2\n3\n");
+        $this->assertTrue($command->execute());
+        $this->assertTrue($command->getExecuted());
+        $this->assertEquals("1", $command->getOutput());
+    }
 
 }

--- a/tests/CommandTest.php
+++ b/tests/CommandTest.php
@@ -226,12 +226,12 @@ class CommandTest extends \PHPUnit\Framework\TestCase
     }
     public function testCanRunCommandWithStandardInput()
     {
-        $command = new Command('head');
-        $command->addArg('-n', 1);
-        $command->setStdIn("1\n2\n3\n");
+        $command = new Command('/bin/cat');
+        $command->addArg('-T');
+        $command->setStdIn("\t");
         $this->assertTrue($command->execute());
         $this->assertTrue($command->getExecuted());
-        $this->assertEquals("1", $command->getOutput());
+        $this->assertEquals("^I", $command->getOutput());
     }
 
 }


### PR DESCRIPTION
These changes will make it possible to 'pipe' a string from php into the standard input stream of the command shell process.

Please consider this pr as I have found it quite useful.

Thank you for a very handy command wrapper!