### PR TITLE
add --read-args-from-stdin option 

### DIFF
--- a/src/Command.php
+++ b/src/Command.php
@@ -207,35 +207,19 @@ class Command
      */
     public function getExecCommand()
     {
-        /*if ($this->_execCommand===null) {
+		if ($this->_execCommand===null)
+		{
             $command = $this->getCommand();
             if (!$command) {
                 $this->_error = 'Could not locate any executable command';
                 return false;
             }
             $args = $this->getArgs();
-            $this->_execCommand = $args ? $command.' '.$args : $command;
-        }
-        return $this->_execCommand;*/
-		        if ($this->_execCommand===null)
-		{
-            $command = $this->getCommand();
-            if (!$command)
-			{
-                $this->_error = 'Could not locate any executable command';
-                return false;
-            }
-            $args = $this->getArgs();
-			if($args && $this->read_args_from_stdin)
-			{
+			if($args && $this->read_args_from_stdin) {
 				$this->_execCommand = $command.' --read-args-from-stdin <'.$this->configFilename;
-			}
-			elseif($args)
-			{
+			} elseif($args)	{
 				$this->_execCommand = $command.' '.$args;
-			}
-			else
-			{
+			} else {
 				$this->_execCommand = $command;
 			}
         }

--- a/src/Command.php
+++ b/src/Command.php
@@ -12,6 +12,16 @@ namespace mikehaertl\shellcommand;
  */
 class Command
 {
+	/**
+     * @var bool. create a config file passed in the stdin of wkhtmltopdf, used on windows for bypass the command line character limit, Default is `false`.
+     */
+    public $read_args_from_stdin = false;
+	
+	/**
+     * @var string|null. used with read_args_from_stdin option. Default is `null` when not used.
+     */
+    public $configFilename;
+	
     /**
      * @var bool whether to escape any argument passed through `addArg()`. Default is `true`.
      */
@@ -197,7 +207,7 @@ class Command
      */
     public function getExecCommand()
     {
-        if ($this->_execCommand===null) {
+        /*if ($this->_execCommand===null) {
             $command = $this->getCommand();
             if (!$command) {
                 $this->_error = 'Could not locate any executable command';
@@ -205,6 +215,29 @@ class Command
             }
             $args = $this->getArgs();
             $this->_execCommand = $args ? $command.' '.$args : $command;
+        }
+        return $this->_execCommand;*/
+		        if ($this->_execCommand===null)
+		{
+            $command = $this->getCommand();
+            if (!$command)
+			{
+                $this->_error = 'Could not locate any executable command';
+                return false;
+            }
+            $args = $this->getArgs();
+			if($args && $this->read_args_from_stdin)
+			{
+				$this->_execCommand = $command.' --read-args-from-stdin <'.$this->configFilename;
+			}
+			elseif($args)
+			{
+				$this->_execCommand = $command.' '.$args;
+			}
+			else
+			{
+				$this->_execCommand = $command;
+			}
         }
         return $this->_execCommand;
     }
@@ -384,6 +417,15 @@ class Command
     public function getIsWindows()
     {
         return strncasecmp(PHP_OS, 'WIN', 3)===0;
+    }
+	
+	
+	/**
+     * @return bool
+     */
+    public function getReadArgsFromStdin()
+    {
+        return $this->read_args_from_stdin;
     }
 
     /**


### PR DESCRIPTION
hello, a little update for add the --read-args-from-stdin option of wkhtmltopdf

the framework is limited by the number of characters in the command line:
https://support.microsoft.com/en-us/help/830473/command-prompt-cmd-exe-command-line-string-limitation

https://wkhtmltopdf.org/usage/wkhtmltopdf.txt

thx you.