### PR TITLE
Escapes spaces in command filename

### DIFF
--- a/src/Command.php
+++ b/src/Command.php
@@ -164,7 +164,7 @@ class Command
 
             // Absolute path. If it's a relative path, let it slide.
             if ($position) {
-                $command = sprintf($command[$position - 1].': && cd %s && %s', escapeshellarg(dirname($command)), basename($command));
+                $command = sprintf($command[$position - 1].': && cd %s && %s', escapeshellarg(dirname($command)), escapeshellarg(basename($command)));
             }
         }
         $this->_command = $command;


### PR DESCRIPTION
This change will allow for the command executable to have spaces in the file name. In Windows this would previously have failed.