### PR TITLE
Fix getExecCommand() to get the latest command set instead only the first…

### DIFF
--- a/src/Command.php
+++ b/src/Command.php
@@ -98,11 +98,6 @@ class Command
     protected $_args = array();
 
     /**
-     * @var string the full command string to execute
-     */
-    protected $_execCommand;
-
-    /**
      * @var string the stdout output
      */
     protected $_stdOut = '';
@@ -239,9 +234,7 @@ class Command
         }
 
         $args = $this->getArgs();
-        $this->_execCommand = $args ? $command.' '.$args : $command;
-        
-        return $this->_execCommand;
+        return $args ? $command.' '.$args : $command;
     }
 
     /**

--- a/src/Command.php
+++ b/src/Command.php
@@ -232,15 +232,15 @@ class Command
      */
     public function getExecCommand()
     {
-        if ($this->_execCommand===null) {
-            $command = $this->getCommand();
-            if (!$command) {
-                $this->_error = 'Could not locate any executable command';
-                return false;
-            }
-            $args = $this->getArgs();
-            $this->_execCommand = $args ? $command.' '.$args : $command;
+        $command = $this->getCommand();
+        if (!$command) {
+            $this->_error = 'Could not locate any executable command';
+            return false;
         }
+
+        $args = $this->getArgs();
+        $this->_execCommand = $args ? $command.' '.$args : $command;
+        
         return $this->_execCommand;
     }
 


### PR DESCRIPTION
Currently` getExecCommand()` outputs only the first command get executed, even if we set a new command via `setCommand()`, a work around it was to reinitiate the `Command` class each time when setting a new command, but with this pull request the issue will be solved.