### PR TITLE
Support the ability to output to console while the command getting executed

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ $command->setStdIn('string');
  * `$escapeArgs`: Whether to escape any argument passed through `addArg()`. Default is `true`.
  * `$escapeCommand`: Whether to escape the command passed to `setCommand()` or the constructor.
     This is only useful if `$escapeArgs` is `false`. Default is `false`.
+ * `$streamOutput`: Whether to echo the output to the console while the current command getting executed. 
+    Default is `false`.
  * `$useExec`: Whether to use `exec()` instead of `proc_open()`. This is a workaround for OS which
    have problems with `proc_open()`. Default is `false`.
  * `$captureStdErr`: Whether to capture stderr when `useExec` is set. This will try to redirect

--- a/src/Command.php
+++ b/src/Command.php
@@ -18,6 +18,12 @@ class Command
     public $escapeArgs = true;
 
     /**
+     * @var bool whether to stream the output of current command getting executed
+     * Default is `false`.
+     */
+    public $streamOutput = false;
+
+    /**
      * @var bool whether to escape the command passed to `setCommand()` or the
      * constructor.  This is only useful if `$escapeArgs` is `false`. Default
      * is `false`.
@@ -469,9 +475,13 @@ class Command
                         //
                         while (($out = fgets($pipes[1])) !== false) {
                             $this->_stdOut .= $out;
+                            if($this->streamOutput)
+                                echo $out;
                         }
                         while (($err = fgets($pipes[2])) !== false) {
                             $this->_stdErr .= $err;
+                            if($this->streamOutput)
+                                echo $err;
                         }
 
                         $runTime = $hasTimeout ? time() - $startTime : 0;
@@ -511,6 +521,18 @@ class Command
                         }
                         fclose($pipes[0]);
                     }
+
+                    if($this->streamOutput)
+                    {
+                        while(!feof($pipes[1]))
+                        {
+                            $return_message = fgets($pipes[1], 1024);
+                            if (strlen($return_message) == 0) break;
+
+                            echo $return_message;
+                        }
+                    }
+                    
                     $this->_stdOut = stream_get_contents($pipes[1]);
                     $this->_stdErr = stream_get_contents($pipes[2]);
                     fclose($pipes[1]);


### PR DESCRIPTION
Currently if a command is getting executed and that takes long then we will never know if it hangs, or still running, even if we want to show the progress it is hard to implement.
My PR is addressing this feature, basically we make `execute()` simulate the behavior of real command gets executed in shell, while still running, the output of command will be echo to console.